### PR TITLE
Pt133614075 fetch bulk responses without paid account

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.0
+current_version = 0.8.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ test_requirements = [
 
 setup(
     name='surveymonkey',
-    version='0.7.0',
+    version='0.8.0',
     description="Python wrapper for the Survey Monkey v3 API",
     long_description=readme,
     author="Aaron Bassett",

--- a/surveymonkey/__init__.py
+++ b/surveymonkey/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = 'Aaron Bassett'
 __email__ = 'engineering@getadministrate.com'
-__version__ = '0.7.0'
+__version__ = '0.8.0'

--- a/surveymonkey/constants.py
+++ b/surveymonkey/constants.py
@@ -8,6 +8,7 @@ URL_SURVEYS_LIST = "%s/surveys" % API_URL
 
 URL_COLLECTOR_CREATE = "%s/surveys/{survey_id}/collectors" % API_URL
 URL_COLLECTOR_SINGLE = "%s/collectors/{collector_id}" % API_URL
+URL_COLLECTOR_RESPONSES = "%s/collectors/{collector_id}/responses" % API_URL
 URL_COLLECTOR_RESPONSES_BULK = "%s/collectors/{collector_id}/responses/bulk" % API_URL
 
 URL_MESSAGE_CREATE = "%s/collectors/{collector_id}/messages" % API_URL

--- a/surveymonkey/manager.py
+++ b/surveymonkey/manager.py
@@ -85,16 +85,19 @@ class BaseManager(object):
         if "links" not in response or "data" not in response:
             raise SurveyMonkeyBadResponse("Unable to process the response. Missing keys.")
 
-    def get_list(self, next_url, max_pages=100):
+    def get_list(self, next_url, max_pages=100, *args, **kwargs):
         guard = 0
         response_list = []
 
         while guard < max_pages and next_url:
             guard += 1
-            response = self.get(base_url=next_url)
+            response = self.get(base_url=next_url, *args, **kwargs)
             self.verify_list_data(response)
             response_list = response_list + response["data"]
             next_url = response["links"]["next"] if "next" in response["links"] else False
+
+            if next_url:
+                kwargs["page"] = furl(next_url).args["page"]
 
         return response_list
 

--- a/surveymonkey/tests/collectors/test_bulk_responses.py
+++ b/surveymonkey/tests/collectors/test_bulk_responses.py
@@ -36,7 +36,7 @@ class TestFetchBulkResponsesForSingleCollector(object):
         )
 
     def test_get_all_responses(self):
-        mock = CollectorResponsesBulkListMock(total=55, collector_ids=self.collector_id)
+        mock = CollectorResponsesBulkListMock(total=55)
         with HTTMock(mock.bulk):
             responses_list = self.bulk_collector.responses()
 
@@ -48,7 +48,6 @@ class TestFetchBulkResponsesForSingleCollector(object):
     def test_get_responses_by_status(self, status, method_name, be_status):
         mock = CollectorResponsesBulkListMock(
             total=5,
-            collector_ids=self.collector_id,
             status=status
         )
 
@@ -71,40 +70,30 @@ class TestFetchBulkResponsesForMultipleCollectors(object):
         ]
         self.bulk_collector = CollectorResponsesBulk(
             connection=self.connection,
-            collector_ids=self.collector_ids,
-            survey_id=random.randint(1234, 567890)
+            collector_ids=self.collector_ids
         )
 
     def test_get_all_responses(self):
-        mock = CollectorResponsesBulkListMock(total=5, collector_ids=self.collector_ids)
+        mock = CollectorResponsesBulkListMock(total=5)
         with HTTMock(mock.bulk):
             responses_list = self.bulk_collector.responses()
 
-        expect(responses_list).to(have_length(5))
+        total_length = len(self.collector_ids) * 5
+        expect(responses_list).to(have_length(total_length))
         expect(responses_list[0]).to(have_keys('analyze_url', 'response_status', 'date_modified'))
         expect(responses_list[0]).to(have_keys('id', 'collector_id', 'recipient_id', 'survey_id'))
-
-    def test_exception_raised_when_survey_id_not_supplied(self):
-        mock = CollectorResponsesBulkListMock(total=5, collector_ids=self.collector_ids)
-        with HTTMock(mock.bulk):
-            with pytest.raises(AttributeError):
-                CollectorResponsesBulk(
-                    connection=self.connection,
-                    collector_ids=self.collector_ids
-                )
-                self.bulk_collector.responses()
 
     @pytest.mark.parametrize("status,method_name,be_status", possible_statuses)
     def test_get_responses_by_status(self, status, method_name, be_status):
         mock = CollectorResponsesBulkListMock(
             total=5,
-            collector_ids=self.collector_ids,
             status=status
         )
 
         with HTTMock(mock.bulk):
             responses_list = getattr(self.bulk_collector, method_name)()
 
-        expect(responses_list).to(have_length(5))
+        total_length = len(self.collector_ids) * 5
+        expect(responses_list).to(have_length(total_length))
         for response in responses_list:
             expect(response).to(be_status)


### PR DESCRIPTION
# Use the free _/responses/_ endpoint not the paid _/bulk/_ endoint

Issues multiple requests to the _/responses/_ endpoint, once for each collector, rather than using the paid accounts only endpoint; _/bulk/_

---

## Checklist

- [x] Meets criteria
- [x] Is modular & tested
- [x] Readable code
- [x] No duplication
- [x] Clear commits
- ~Documentation updated~
- [x] Handled error cases
- [x] **Code always improving**

https://www.pivotaltracker.com/story/show/133614075