### PR TITLE
Pt#134012945 fix reminder bug with missing field

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.0
+current_version = 0.8.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ test_requirements = [
 
 setup(
     name='surveymonkey',
-    version='0.8.0',
+    version='0.8.1',
     description="Python wrapper for the Survey Monkey v3 API",
     long_description=readme,
     author="Aaron Bassett",

--- a/surveymonkey/__init__.py
+++ b/surveymonkey/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = 'Aaron Bassett'
 __email__ = 'engineering@getadministrate.com'
-__version__ = '0.8.0'
+__version__ = '0.8.1'

--- a/surveymonkey/messages/configs.py
+++ b/surveymonkey/messages/configs.py
@@ -14,6 +14,7 @@ class ReminderConfig(BaseConfig):
     def __init__(self, **kwargs):
         super(ReminderConfig, self).__init__(**kwargs)
         self.type = "reminder"
+        self.recipient_status = "has_not_responded"
 
 
 def is_invite(type):

--- a/surveymonkey/messages/messages.py
+++ b/surveymonkey/messages/messages.py
@@ -20,7 +20,7 @@ class Message(BaseManager):
         )
         response = self.post(
             base_url=url,
-            data={"type": self.config.type}
+            data=self.config.vars()
         )
         self.message_id = response["id"]
         return response

--- a/surveymonkey/surveymonkey.py
+++ b/surveymonkey/surveymonkey.py
@@ -14,3 +14,6 @@ class BaseConfig(object):
     def __init__(self, **kwargs):
         for key, value in six.iteritems(kwargs):
             setattr(self, key, value)
+
+    def vars(self):
+        return vars(self)

--- a/surveymonkey/tests/messages/matchers/messages.py
+++ b/surveymonkey/tests/messages/matchers/messages.py
@@ -2,12 +2,17 @@
 from __future__ import absolute_import
 
 from expects.matchers import Matcher
-from surveymonkey.messages.configs import is_invite
+from surveymonkey.messages.configs import is_invite, is_reminder
 
 
 class BeInvite(Matcher):
     def _match(self, response):
         return is_invite(response["type"]), []
+
+
+class BeReminder(Matcher):
+    def _match(self, response):
+        return is_reminder(response["type"]), []
 
 
 class BeSent(Matcher):
@@ -16,6 +21,7 @@ class BeSent(Matcher):
 
 
 be_invite = BeInvite()
+be_reminder = BeReminder()
 be_sent = BeSent()
 
-__all__ = ['be_invite', 'be_sent']
+__all__ = ['be_invite', 'be_reminder', 'be_sent']

--- a/surveymonkey/tests/messages/test_message_configs.py
+++ b/surveymonkey/tests/messages/test_message_configs.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from expects import expect, equal
+from expects import expect, equal, have_property
 
 from surveymonkey.messages import InviteConfig, ReminderConfig
 from surveymonkey.tests.messages.matchers.configs import be_invite, be_reminder
@@ -17,6 +17,10 @@ class TestMessageConfigs(object):
     def test_type_is_reminder_when_using_the_reminder_configurator(self):
         configuration = ReminderConfig()
         expect(configuration).to(be_reminder)
+
+    def test_reminder_has_correct_recipient_status(self):
+        config = ReminderConfig()
+        expect(config).to(have_property("recipient_status"))
 
     def test_config_accepts_extra_values(self):
         config = InviteConfig(subject="My Test Message")

--- a/surveymonkey/tests/messages/test_messages.py
+++ b/surveymonkey/tests/messages/test_messages.py
@@ -12,8 +12,8 @@ from expects import expect, have_key, have_length, be_above_or_equal
 from httmock import HTTMock
 from mock import MagicMock
 
-from surveymonkey.messages import Message, InviteConfig
-from surveymonkey.tests.messages.matchers.messages import be_sent, be_invite
+from surveymonkey.messages import Message, InviteConfig, ReminderConfig
+from surveymonkey.tests.messages.matchers.messages import be_sent, be_invite, be_reminder
 
 from surveymonkey.constants import URL_MESSAGE_SEND
 from surveymonkey.tests.mocks.messages import (MessagesMock, MessagesRecipientsMock,
@@ -44,6 +44,19 @@ class TestCreateMessages(object):
         expect(invite).to_not(be_sent)
         expect(invite).to(be_invite)
         expect(invite).to(have_key("id"))
+
+    def test_reminder_created(self):
+        config = ReminderConfig()
+        message = Message(
+            connection=self.connection,
+            collector_id=self.collector_id,
+            config=config
+        )
+
+        with HTTMock(MessagesMock(config).create):
+            reminder = message.create()
+
+        expect(reminder).to(be_reminder)
 
 
 class RecipientLists(object):

--- a/surveymonkey/tests/test_base_config.py
+++ b/surveymonkey/tests/test_base_config.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from expects import expect, equal
+from expects import expect, equal, be_a
 from surveymonkey.surveymonkey import BaseConfig
 
 
@@ -14,3 +14,14 @@ class TestBaseConfig(object):
         )
 
         expect(config.company).to(equal("Administrate"))
+
+    def test_base_config_var_returns_valid_dict_of_all_vars(self):
+        custom_vars = {
+            "company": "Administrate",
+            "location": "Edinburgh"
+        }
+        config = BaseConfig(**custom_vars)
+        config_vars = config.vars()
+
+        expect(config_vars).to(be_a(dict))
+        expect(config_vars).to(equal(custom_vars))


### PR DESCRIPTION
# recipient_status is a required field for reminder

Contrary to what the SurveyMonkey docs say it appears `receipient_status` is a required field when creating a reminder. Ensure this is sent when a reminder is created by adding it to the reminder config.

![Lies!](https://i.imgur.com/2eCBgkn.png)

---

## Checklist

- [x] Meets criteria
- [x] Is modular & tested
- [x] Readable code
- [x] No duplication
- [x] Clear commits
- ~Documentation updated~
- [x] Handled error cases
- [x] **Code always improving**

https://www.pivotaltracker.com/story/show/134012945