### PR TITLE
Temporarily remove prospector

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, flake8, bandit, prospector
+envlist = py27, py35, flake8, bandit
 
 [flake8]
 max-line-length = 99
@@ -13,11 +13,6 @@ commands=flake8 surveymonkey
 basepython=python
 deps=bandit
 commands=bandit -x tests/ -r surveymonkey/
-
-[testenv:prospector]
-basepython=python
-deps=prospector
-commands=prospector --strictness high
 
 [testenv]
 setenv =


### PR DESCRIPTION
One of the dependencies is stomping over prospector's
requirements and causing it to error out. Remove
Prospector temporarily while we look into what is
over-writing the requirements
