### PR TITLE
Update base manager to take access url

### DIFF
--- a/surveymonkey/constants.py
+++ b/surveymonkey/constants.py
@@ -3,20 +3,20 @@
 BASE_URL = "http://www.surveymonkey.com"
 API_URL = "https://api.surveymonkey.net/v3"
 
-URL_USER_ME = "%s/users/me" % API_URL
+URL_USER_ME = "/users/me"
 
-URL_SURVEYS_DETAIL = "%s/surveys/{survey_id}/details" % API_URL
-URL_SURVEYS_LIST = "%s/surveys" % API_URL
-URL_SURVEY_RESPONSES_BULK = "%s/surveys/{survey_id}/responses/bulk" % API_URL
+URL_SURVEYS_DETAIL = "/surveys/{survey_id}/details"
+URL_SURVEYS_LIST = "/surveys"
+URL_SURVEY_RESPONSES_BULK = "/surveys/{survey_id}/responses/bulk"
 
-URL_COLLECTOR_CREATE = "%s/surveys/{survey_id}/collectors" % API_URL
-URL_COLLECTOR_SINGLE = "%s/collectors/{collector_id}" % API_URL
-URL_COLLECTOR_RESPONSES_BULK = "%s/collectors/{collector_id}/responses/bulk" % API_URL
+URL_COLLECTOR_CREATE = "/surveys/{survey_id}/collectors"
+URL_COLLECTOR_SINGLE = "/collectors/{collector_id}"
+URL_COLLECTOR_RESPONSES_BULK = "/collectors/{collector_id}/responses/bulk"
 
-URL_MESSAGE_CREATE = "%s/collectors/{collector_id}/messages" % API_URL
-URL_MESSAGE_RECIPIENT_ADD_BULK = "%s/collectors/{collector_id}/messages/{message_id}/recipients/bulk" % API_URL  # noqa:E501
-URL_MESSAGE_SEND = "%s/collectors/{collector_id}/messages/{message_id}/send" % API_URL
+URL_MESSAGE_CREATE = "/collectors/{collector_id}/messages"
+URL_MESSAGE_RECIPIENT_ADD_BULK = "/collectors/{collector_id}/messages/{message_id}/recipients/bulk"  # noqa:E501
+URL_MESSAGE_SEND = "/collectors/{collector_id}/messages/{message_id}/send"
 
-URL_RESPONSE_DETAIL = "%s/surveys/{survey_id}/responses/{response_id}/details" % API_URL
+URL_RESPONSE_DETAIL = "/surveys/{survey_id}/responses/{response_id}/details"
 
-URL_WEBHOOKS = "%s/webhooks" % API_URL
+URL_WEBHOOKS = "/webhooks"

--- a/surveymonkey/manager.py
+++ b/surveymonkey/manager.py
@@ -6,6 +6,7 @@ import requests
 from furl import furl
 import json
 
+from surveymonkey.constants import API_URL
 from .exceptions import response_raises, SurveyMonkeyBadResponse
 
 
@@ -13,6 +14,7 @@ class BaseManager(object):
 
     def __init__(self, connection):
         self.connection = connection
+        self.access_url = getattr(connection, 'access_url', None)
 
     def create_session(self):
         session = requests.Session()
@@ -23,7 +25,13 @@ class BaseManager(object):
 
         return session
 
+    def add_base_url(self, url):
+        if str(self.access_url) in url or API_URL in url:
+            return url
+        return (self.access_url or API_URL) + url
+
     def build_url(self, url, *args, **kwargs):
+        url = self.add_base_url(url)
         page = kwargs.get("page", None)
         per_page = kwargs.get("per_page", None)
 

--- a/surveymonkey/surveymonkey.py
+++ b/surveymonkey/surveymonkey.py
@@ -6,8 +6,9 @@ import six
 
 class SurveyMonkeyConnection(object):
 
-    def __init__(self, access_token):
+    def __init__(self, access_token, access_url=None):
         self.ACCESS_TOKEN = access_token
+        self.ACCESS_URL = access_url
 
 
 class BaseConfig(object):

--- a/surveymonkey/tests/test_base_manager.py
+++ b/surveymonkey/tests/test_base_manager.py
@@ -10,7 +10,7 @@ from expects import expect, have_key, have_keys, equal, be_a, contain
 from mock import MagicMock
 
 from surveymonkey.manager import BaseManager
-from surveymonkey.constants import URL_USER_ME
+from surveymonkey.constants import URL_USER_ME, API_URL
 from surveymonkey.exceptions import SurveyMonkeyBadResponse
 
 from surveymonkey.tests.utils import create_fake_connection
@@ -34,7 +34,7 @@ class TestBaseManager(object):
 
     def test_parse_response_returns_a_dict_with_correct_keys(self):
         with HTTMock(UsersResponseMocks().me):
-            response = self.session.get(URL_USER_ME)
+            response = self.session.get(API_URL + URL_USER_ME)
             data = self.manager.parse_response(response)
 
             expect(data).to(have_keys('id', 'username', 'email'))
@@ -146,3 +146,27 @@ class TestBaseManager(object):
 
         self.manager.set_quotas(response)
         expect(self.manager.quota_exceeded).to(equal(False))
+
+    def test_access_url_overrides_api_url_when_provided(self):
+        connection = MagicMock(
+            connection=self.connection,
+            access_url="http://overridden.com"
+        )
+        manager = BaseManager(connection)
+
+        overriden_url = manager.build_url(URL_USER_ME)
+        expect(overriden_url).to(equal("http://overridden.com" + URL_USER_ME))
+
+    def test_add_base_url_handles_pre_formatted_urls(self):
+        connection = MagicMock(
+            connection=self.connection,
+            access_url="http://overridden.com"
+        )
+        manager = BaseManager(connection)
+        formatted_overridden_url = "http://overridden.com" + URL_USER_ME
+        formatted_default_url = API_URL + URL_USER_ME
+
+        overriden_url = manager.build_url(formatted_overridden_url)
+        default_url = manager.build_url(formatted_default_url)
+        expect(overriden_url).to(equal(formatted_overridden_url))
+        expect(default_url).to(equal(formatted_default_url))


### PR DESCRIPTION
The api url for survey monkey can be different based on where you
signed up for your account, see:
https://developer.surveymonkey.com/api/v3/#access-url

This change allows the base manager to take both a connection object with an
access url and the previous connection value by itself. This allows the
api url to be overridden when necessary.

see: https://www.pivotaltracker.com/story/show/157116253

---

## Checklist

- [ ] Meets criteria
- [ ] Is modular & tested
- [ ] Readable code
- [ ] No duplication
- [ ] Clear commits
- [ ] Documentation updated
- [ ] Handled error cases
- [ ] **Code always improving**

**Do not wait until you can tick off each item to open your PR. Open it early as early feedback on implementation and design strategy can be useful to ensure that the work is progressing in a way that matches the overall vision for the project and the code.**

But please ensure that you tick off as many points from the checklist as feasibly possible for your
project before submitting for Code Review.

[Code Review Guidelines]: https://eaglewood.administrateapp.com/KB/view/id/code-review-guidelines
[well formed]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
